### PR TITLE
Allow timer to force game end

### DIFF
--- a/ARRASTRA Y JUEGA- JAFERYAC/RECICLA Y JUEGA.cs
+++ b/ARRASTRA Y JUEGA- JAFERYAC/RECICLA Y JUEGA.cs
@@ -177,11 +177,11 @@
         }
 
         //VERIFICACIÓN DEL FIN DEL JUEGO
-        private void verificarfin()
+        private void verificarfin(bool forzarFin = false)
         {
             foreach (var pb in basuras)
             {
-                if (pb.Visible) return; // si queda basura, salimos
+                if (pb.Visible && !forzarFin) return; // si queda basura y no se fuerza el fin, salimos
             }
 
             //MI TEMPORIZADOR SE DETENDRA CUANDO SE HAYAN COLOCADO TODA LA BASURA EN SUS BASUREROS Y MOSTRARA UN FORMULARIO
@@ -255,7 +255,7 @@
             if (tiempo <= 0)
             {
                 temporizador.Stop();
-                verificarfin(); // usamos el mismo formulario de fin de juego
+                verificarfin(forzarFin: true); // usamos el mismo formulario de fin de juego
             }
         }
     }


### PR DESCRIPTION
## Summary
- Allow `verificarfin` to optionally bypass visible trash check via new `forzarFin` flag
- When timer expires, trigger final check with forced finish

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bac2c817f4832581acb68b3c52ec88