### PR TITLE
Ajustar visibilidad y puntaje al soltar basuras

### DIFF
--- a/ARRASTRA Y JUEGA- JAFERYAC/RECICLA Y JUEGA.cs
+++ b/ARRASTRA Y JUEGA- JAFERYAC/RECICLA Y JUEGA.cs
@@ -120,9 +120,19 @@
                 (pb == PictureBoxBanana && pb.Bounds.IntersectsWith(pictureBoxNaranja.Bounds)) ||
                 (pb == pictureBoxHoja && pb.Bounds.IntersectsWith(pictureBoxNaranja.Bounds)))
             {
+                correcta = true;
+                pb.Visible = false;
+            }
+            else
+            {
+                pb.Location = posicionesOriginales[pb];
+                pb.Visible = true;
+            }
+
+            if (correcta)
+            {
                 //POR CADA ACIERTO SON 10 PUNTOS
                 puntos += 10;
-                correcta = true;
             }
             else
             {
@@ -131,7 +141,6 @@
                 if (puntos < 0) puntos = 0; // PARA QUE NO PASE DE 0 Y TENGA PUNTOS NEGATIVOS
             }
 
-            pb.Visible = false; // OCULTO LA BASURA AUNQUE ESTE MAL RECICLADA 
             LabelPorcentaje.Text = "PUNTOS: " + puntos;
             verificarfin();
         }


### PR DESCRIPTION
## Summary
- Al arrastrar y soltar basuras, se ocultan solo las piezas correctamente recicladas
- Las basuras mal colocadas regresan a su posición original y permanecen visibles
- El puntaje y la verificación de fin se actualizan tras reubicar u ocultar las piezas

## Testing
- `dotnet build 'ARRASTRA Y JUEGA- JAFERYAC.sln'` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bac2d03fcc832588738e3d73140613